### PR TITLE
Functionality to disable puppet/hiera installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Then you will need to make add an environment that uses the Puppet provisioner t
 
 --puppet-hieradata - The name of the tarball containing a hiera.yaml file and hieradata directory.  This option requires Puppet >= 3.1.')
 
+--puppet-install-puppet - Specify if puppet provisioner should install puppet and hiera. Default is "true".
+
 --puppet-install-cmd - The command to use to install Puppet.  The native package manager will be used by default.
 
 --puppet-hiera-install-cmd - The command to use to install Hiera.  Gem will be used by default.
@@ -68,6 +70,13 @@ sudo aminate -B ami-35792c5c --puppet-master=puppet-master.domain.com some-host.
 
 Puppet will use the specified hostname to try to talk to the Puppet Master server and generate certs with the name in the last argument.
 
+### Master specified, don't attempt to install puppet or hiera
+
+```
+sudo aminate -B ami-35792c5c --puppet-master=puppet-master.domain.com --puppet-install-puppet=false some-host.domain.com
+```
+
+Puppet will use the specified hostname to try to talk to the Puppet Master server and generate certs with the name in the last argument. Puppet provisioner will not attempt to install OS packages for puppet or hiera, but will assume they are already installed.
 
 ## Usage Masterless
 

--- a/aminatorplugins/provisioner/puppet.py
+++ b/aminatorplugins/provisioner/puppet.py
@@ -79,6 +79,10 @@ class PuppetProvisionerPlugin(BaseProvisionerPlugin):
                                     action=conf_action(self._config.plugins[self.full_name]),
                                     help='The name of the tarball containing a hiera.yaml file and hieradata directory.  This option requires Puppet >= 3.1.')
 
+        puppet_config.add_argument('--puppet-install-puppet', dest='puppet_install_puppet',
+                                    action=conf_action(self._config.plugins[self.full_name]),
+                                    help='Specify if puppet provisioner should install puppet and hiera. Default is "true".')
+
         puppet_config.add_argument('--puppet-install-cmd', dest='puppet_install_cmd',
                                     action=conf_action(self._config.plugins[self.full_name]),
                                     help='The command to use to install Puppet.  The native package manager will be used by default.')
@@ -101,7 +105,7 @@ class PuppetProvisionerPlugin(BaseProvisionerPlugin):
         overrides the base provision
       * generate certificates
       * install the certificates on the target volume
-          * install puppet on the target volume
+          * install puppet on the target volume (if puppet_install_puppet is true)
       * run the puppet agent in the target chroot environment
         """
 
@@ -125,7 +129,10 @@ class PuppetProvisionerPlugin(BaseProvisionerPlugin):
         log.debug('Entering chroot at {0}'.format(self._distro._mountpoint))
         with Chroot(self._distro._mountpoint):
 
-            self._install_puppet()
+            puppet_install_puppet = self._get_config_value('puppet_install_puppet', 'true')
+
+            if puppet_install_puppet == "true":
+                self._install_puppet()
 
             puppet_args = self._get_config_value('puppet_args', '' )
 


### PR DESCRIPTION
If a base image already has puppet installed, puppet provisioner
attempting to re-install these packages just wastes time.
